### PR TITLE
URL and text fixes

### DIFF
--- a/coq/HTT.v
+++ b/coq/HTT.v
@@ -55,8 +55,8 @@ transparency_ property, which ensures that programs in such languages
 expressions, evaluating to some result (similar to mathematical
 functions) or diverging. Therefore, such programs, whose outcome is
 only a value, but not some side effect (e.g., output to a file), can
-be replaced safely by their result, if it's computable. This
-possibility provides a convenient way of algebraic reasoning about
+be replaced safely by their result, if it is computable. This
+possibility provides a convenient way of reasoning algebraically about
 such programs by means of equality rewritings---precisely what we were
 observing and leveraging in %Chapters~\ref{ch:eqrew}
 and~\ref{ch:ssrstyle}% of this course in the context of Coq taken as a
@@ -72,11 +72,11 @@ some of the program's algebraic properties. While a functional program
 is already a good description of its result (due to referential
 transparency), its algebraic properties (e.g., some equalities that
 hold over it) are usually a subject of separate statements, which
-should be proved%~\cite{Bird:BOOK}%. Good example of such properties
+should be proved%~\cite{Bird:BOOK}%. Good examples of such properties
 are the commutativity and cancellation properties, which we proved for
 natural numbers with addition, considered as an instance of PCM on
 page%~\pageref{pg:addnprops} of Chapter~\ref{ch:depstruct}%. Another
-classical series of examples, which we did not focus in this course,
+classical series of examples, which we did not focus on in this course,
 are properties of list functions, such as appending and reversal
 (e.g., that the list reversal is an inverse to itself).%\footnote{A
 common anti-pattern in dependently-typed languages and Coq in
@@ -1153,7 +1153,7 @@ of separation logic, and [[vfun x => ...]] notation accounts for the
 fact that the computation can throw an
 exception%~\cite{Nanevski-al:JFP08}%, the possibility we do not
 discuss in this course.
-** Structuring the program verification in HTT 
+** Structuring program verification in HTT
 Let us now consider how the examples from %Section~\ref{sec:seplog}%
 can be given specifications and verified in Coq. The program on
 page%~\pageref{pg:alterx}%, which modifies a pointer [x] and keeps a
@@ -1833,7 +1833,7 @@ Qed.
 *)
 
 (**
-* On shallow and deep embedding
+* On shallow and deep embeddings
 %\label{sec:shallowdeep}%
 A noteworthy trait of HTT's approach to verification of effectful
 programs is its use of _shallow embedding_ of the imperative language

--- a/coq/Introduction.v
+++ b/coq/Introduction.v
@@ -200,7 +200,7 @@ Alternatively, instead of running %\texttt{make install}%, one can set up the en
 
 ** Emacs set-up
 
-Emacs%\footnote{\url{http://www.gnu.org/software/emacs/}}% (or Aquamacs%\footnote{\url{http://aquamacs.org/}}% for Mac OS X users) text editor provides a convenient environment for Coq development, thanks to the Proof General mode. After downloading and installing Emacs, clone the Git repository of Proof General,%\footnote{Available from \url{https://github.com/emacsattic/proofgeneral}.}% and Mathematical Components%
+Emacs%\footnote{\url{http://www.gnu.org/software/emacs/}}% (or Aquamacs%\footnote{\url{http://aquamacs.org/}}% for Mac OS X users) text editor provides a convenient environment for Coq development, thanks to the Proof General mode. After downloading and installing Emacs, clone the Git repository of Proof General,%\footnote{Available from \url{https://github.com/ProofGeneral/PG}.}% and Mathematical Components%
 footnote{Available from \url{https://github.com/math-comp/math-comp}}% following the instructions below.
 Upon cloning both repositories, for instance, into the folders <<~/misc/PG/>> and <<~/misc/math-comp/>> add the following lines into the %\texttt{.emacs}% configuration file located in the home directory in Unix and in <<C:\>> root in Windows (possibly replacing the %\texttt{\textasciitilde/misc/}% part with the path where Proof General and Ssreflect/MathComp repositories were).
 

--- a/coq/Introduction.v
+++ b/coq/Introduction.v
@@ -200,9 +200,8 @@ Alternatively, instead of running %\texttt{make install}%, one can set up the en
 
 ** Emacs set-up
 
-Emacs%\footnote{\url{http://www.gnu.org/software/emacs/}}% (or Aquamacs%\footnote{\url{http://aquamacs.org/}}% for Mac OS X users) text editor provides a convenient environment for Coq development, thanks to the Proof General mode. After downloading and installing Emacs, clone the Git repository of Proof General,%\footnote{Available from \url{https://github.com/ProofGeneral/PG}.}% and Mathematical Components%
-footnote{Available from \url{https://github.com/math-comp/math-comp}}% following the instructions below.
-Upon cloning both repositories, for instance, into the folders <<~/misc/PG/>> and <<~/misc/math-comp/>> add the following lines into the %\texttt{.emacs}% configuration file located in the home directory in Unix and in <<C:\>> root in Windows (possibly replacing the %\texttt{\textasciitilde/misc/}% part with the path where Proof General and Ssreflect/MathComp repositories were).
+The Emacs%\footnote{\url{http://www.gnu.org/software/emacs/}}% (or Aquamacs%\footnote{\url{http://aquamacs.org/}}% for Mac OS X users) text editor provides a convenient environment for Coq development, thanks to the Proof General mode. After downloading and installing Emacs, clone the Git repository of Proof General,%\footnote{\url{https://github.com/ProofGeneral/PG}}% and Mathematical Components%\footnote{\url{https://github.com/math-comp/math-comp}}% following the instructions below.
+Upon cloning both repositories, for instance, into the folders <<~/misc/PG/>> and <<~/misc/math-comp/>>, add the following lines into the %\texttt{.emacs}% configuration file located in the home directory in Unix and in the <<C:\>> root in Windows (possibly replacing the %\texttt{\textasciitilde/misc/}% part with the path where the Proof General and Ssreflect/MathComp repositories were).
 
 << 
 ;; Proof General support 

--- a/coq/Introduction.v
+++ b/coq/Introduction.v
@@ -211,7 +211,7 @@ Upon cloning both repositories, for instance, into the folders <<~/misc/PG/>> an
 (load-file "~/misc/math-comp/mathcomp/ssreflect/pg-ssr.el") 
 >>
 
-Linux users, more used to the Windows-style Copy/Paste/Undo keystrokes can also find it convenient to enable the Cua mode in Emacs, which can be done by adding the following lines into the %\texttt{.emacs}% file:
+Linux users who are more used to the Windows-style Copy/Paste/Undo keystrokes can also find it convenient to enable the Cua mode in Emacs, which can be done by adding the following lines into the %\texttt{.emacs}% file:
 
 << 
 (cua-mode t) 

--- a/coq/Introduction.v
+++ b/coq/Introduction.v
@@ -222,6 +222,7 @@ Linux users who are more used to the Windows-style Copy/Paste/Undo keystrokes ca
 
 Every Coq file has the extension %\texttt{.v}%. Opening any %\texttt{.v}% file will automatically trigger the Proof General mode.
 
+Finally, the optional Company-Coq%\footnote{\url{https://github.com/cpitclaudel/company-coq}}% collection of extensions to Proof General adds many modern IDE features such as auto-completion of tactics and names, refactoring, and inline help.
 
 ** Getting the lecture files and solutions
 %\label{sec:get-files}%


### PR DESCRIPTION
Here are some fixes to grammar and URLs. Also, I added a mention of the [Company-Coq](https://github.com/cpitclaudel/company-coq) extensions to Proof General, which should be interesting to beginners who are used to IDEs like Eclipse and IntelliJ.