### PR TITLE
Fix a few small typos

### DIFF
--- a/coq/BoolReflect.v
+++ b/coq/BoolReflect.v
@@ -667,7 +667,7 @@ This is why we need a mechanism to conveniently switch between two
 possible representation. Ssreflect solves this problem by employing
 the familiar rewriting machinery (%see Section~\ref{sec:indexed} of
 Chapter~\ref{ch:eqrew}%) and introducing the inductive predicate
-family [reflect], which connects propositions an booleans:
+family [reflect], which connects propositions and booleans:
 
 %\ssrd{reflect}%
 %\index{reflect datatype@{\textsf{reflect} datatype}}%

--- a/coq/FunProg.v
+++ b/coq/FunProg.v
@@ -621,7 +621,7 @@ Inductive strange : Set :=  cs : strange -> strange.
 (** 
 
 Therefore, an attempt to create a value of type [strange] by invoking
-its single constructor will inevitably lead to an infinie,
+its single constructor will inevitably lead to an infinite,
 non-terminating, series of constructor calls, and such programs cannon
 be encoded in Coq. It is interesting to take a look at the recursion
 principle of [strange]:

--- a/coq/Rewriting.v
+++ b/coq/Rewriting.v
@@ -77,7 +77,7 @@ universes) and an element [x] of type [A]. There is nothing
 particularly new here: we have seen parametrized inductive predicates
 before, for instance, conjunction and disjunction in
 %Section~\ref{sec:conjdisj}%. The novel part of this definition is
-what comes after the semicolon trailing the parameter list. Unlike all
+what comes after the colon trailing the parameter list. Unlike all
 previously seen logical connectives, the equality predicate has type
 [A -> Prop] in contrast to just [Prop]. In the Coq terminology, it
 means that [eq] is not just inductively-defined datatype, but is an

--- a/coq/SsrStyle.v
+++ b/coq/SsrStyle.v
@@ -144,7 +144,7 @@ case: c; first by [].
 
 Now, right after case-analysing on [c], the proof script specifies
 that the _first_ of the generated subgoals should be solved using [by
-[].]. In this case %\texttt{first}% is called _selector_, and its
+[]]. In this case %\texttt{first}% is called _selector_, and its
 counterpart %\texttt{last}% would specify that the last goal should be
 taken care of instead, before proceeding.
 


### PR DESCRIPTION
This fixes a couple minor typos I found in the PDF, and one stylistic fix where a command at the end of a sentence resulted in a double period (so I removed the inner period). 