### PR TITLE
Fixes for compatibility and clarity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,16 @@ TEX          := $(MODULES:%=latex/%.v.tex)
 COQNOTES     := pnp
 
 default: Makefile.coq
-	make -f Makefile.coq
+	$(MAKE) -f Makefile.coq all
 
 clean: Makefile.coq
-	make -f Makefile.coq cleanall
-	rm -f Makefile.coq
+	$(MAKE) -f Makefile.coq cleanall
+	rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 
-.PHONY: coq clean doc
+.PHONY: coq clean doc zip
 
 doc: latex/$(COQNOTES).pdf
 
@@ -29,6 +29,5 @@ latex/%.pdf: latex/%.tex latex/references.bib latex/proceedings.bib latex/defs.t
 	cd latex && pdflatex $* && pdflatex $* && bibtex $* -min-crossrefs=99 && makeindex $* && pdflatex $* && pdflatex $*
 
 zip:
-	rm pnp.zip
+	rm -f pnp.zip
 	zip pnp.zip ../pnp/Makefile ../pnp/lectures/*.v ../pnp/coq/*.v ../pnp/solutions/*.v ../pnp/htt/*.v ../pnp/latex/*.sty ../pnp/latex/*.bib ../pnp/latex/pnp.tex ../pnp/latex/*.png ../pnp/latex/defs.tex ../pnp/_CoqProject
-

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ Makefile.coq: _CoqProject
 doc: latex/$(COQNOTES).pdf
 
 latex/%.v.tex: Makefile coq/%.v coq/%.glob coq/Introduction.v coq/FunProg.v coq/LogicPrimer.v coq/Rewriting.v coq/BoolReflect.v coq/SsrStyle.v coq/DepRecords.v coq/HTT.v coq/Conclusion.v
-	cd coq ; coqdoc --interpolate --latex --body-only -s \
+	cd coq ; coqdoc --no-externals --interpolate --latex --body-only -s \
 		$*.v -o ../latex/$*.v.tex
 
 latex/$(COQNOTES).pdf: latex/$(COQNOTES).tex $(TEX) latex/references.bib latex/proceedings.bib latex/defs.tex 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,7 +1,12 @@
 -Q htt HTT
 -Q coq PnP
 -Q solutions PnPSolutions
--arg "-w -notation-overridden,-local-declaration,-redundant-canonical-projection,-projection-no-head-constant"
+
+-arg -w -arg -notation-overridden
+-arg -w -arg -local-declaration
+-arg -w -arg -redundant-canonical-projection
+-arg -w -arg -projection-no-head-constant
+-arg -w -arg -undo-batch-mode
 
 htt/domain.v
 htt/heaptac.v
@@ -26,4 +31,3 @@ solutions/BoolReflect_solutions.v
 solutions/SsrStyle_solutions.v
 solutions/DepRecords_solutions.v
 solutions/HTT_solutions.v
-

--- a/coq/Introduction.v
+++ b/coq/Introduction.v
@@ -158,14 +158,14 @@ Alternatively, you can clone the the sources of these lecture notes, along with 
 
 ** Installing Coq, Ssreflect and Mathematical Components
 
-The sources of this manuscript have been compiled and tested with Coq version 8.8, Ssreflect/Mathematical Components version 1.7.0, and FCSL PCM version 1.0.0. It is not guaranteed that the same examples will work seamlessly with different versions. Therefore, several recipes on how to build install the necessary software are provided below.
+The sources of this manuscript have been compiled and tested with Coq version 8.8.2, Ssreflect/Mathematical Components version 1.7.0, and FCSL PCM version 1.0.0. It is not guaranteed that the same examples will work seamlessly with different versions. Therefore, several recipes on how to build install the necessary software are provided below.
 
 The easiest way to obtain the necessary versions of Coq/Ssreflect is
 to install them via OPAM package manager
 (%\url{https://opam.ocaml.org/}%): 
 
 << 
-opam install coq
+opam install coq.8.8.2
 >>
 
 
@@ -178,7 +178,7 @@ opam repo add coq-released https://coq.inria.fr/opam/released
 opam install coq-mathcomp-ssreflect.1.7.0 coq-fcsl-pcm.1.0.0
 >>
 
-Alternatively, you can compile Coq 8.8, Ssreflect/Mathematical
+Alternatively, you can compile Coq 8.8.2, Ssreflect/Mathematical
 Components version 1.7.0, and FCSL PCM 1.0.0 from sources, which would take around an hour.%\footnote{Getting Coq using a system-specific package
 manager, such as \emph{aptitude} or \emph{MacPorts} is another option,
 although the Coq version acquired this way is not guaranteed to work

--- a/coq/LogicPrimer.v
+++ b/coq/LogicPrimer.v
@@ -161,8 +161,9 @@ with propositions and proofs.
 From mathcomp.ssreflect Require Import ssreflect.
 
 (* begin hide *)
-Module LogicPrimer.
+Require Classical_Prop.
 
+Module LogicPrimer.
 (* end hide *)
  
 (**
@@ -1452,7 +1453,7 @@ example on page 414 of the Coq'Art book).
 
 *)
 
-Require Import Classical_Prop.
+Import Classical_Prop.
 
 
 (**

--- a/solutions/LogicPrimer_solutions.v
+++ b/solutions/LogicPrimer_solutions.v
@@ -1,9 +1,11 @@
 From mathcomp.ssreflect
 Require Import ssreflect.
 
+Require Classical_Prop.
+
 Module LogicPrimer.
 
-Require Import Classical_Prop.
+Import Classical_Prop.
 Definition peirce_law := forall P Q: Prop, ((P -> Q) -> P) -> P.
 
 (**


### PR DESCRIPTION
Here are a few fixes to address:
- compatibility with `coqide` in `_CoqProject`
- Coq deprecations
- broken URLs to constants such as `nat` in the PDF (now disabled)
- installation instructions for a specific Coq version
- Makefile issues

Any chance for a release on the website to allow referring people an up-to-date version of the book? I'd also recommend putting the website sources in the repository to allow updates via pull requests.

Finally, could I use `coq-logo.png` in some of my presentation slides?