### PR TITLE
Print `Bool.reflect` instead of redefining it

### DIFF
--- a/coq/BoolReflect.v
+++ b/coq/BoolReflect.v
@@ -674,17 +674,14 @@ family [reflect], which connects propositions and booleans:
 
 *)
 
-(* begin hide *)
-Module Inner.
-(* end hide *)
-Inductive reflect (P : Prop) : bool -> Set :=
-  | ReflectT  of   P : reflect P true
-  | ReflectF of ~ P : reflect P false.
-(* begin hide *)
-End Inner.
-(* end hide *)
+Print Bool.reflect.
 
 (**
+[[
+Inductive reflect (P : Prop) : bool -> Set :=
+  | ReflectT of   P : reflect P true
+  | ReflectF of ~ P : reflect P false.
+]]
 
 Similarly to the custom rewriting rules, the [reflect] predicate is
 nothing but a convenient way to encode a "truth" table with respect to


### PR DESCRIPTION
This pull request aims to resolve #18 .

I decided to simply `Print` the original definition instead of working around redefinition.
I think that working around redefinition would be a wrong choice, because a reader wouldn't be able to use lemmas proved for the original definition in the exercises.

I didn't update `/docs/pnp.pdf` with this commit because I wanted to avoid binary noise in case changes are necessary. You can see updated book here: http://srv04.mikr.us:30449/tmp/pnp.pdf